### PR TITLE
Fix compiler warnings: change int to size_t

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -54,9 +54,9 @@ option *parse_long(args *args, const char *argument) {
     };
 
     // index that separates present=1 and present=-1
-    int sepindex = 3;
+    size_t sepindex = 3;
 
-    for (int j = 0; j < sizeof(prefixes) / sizeof(char*); ++j) {
+    for (size_t j = 0; j < sizeof(prefixes) / sizeof(char*); ++j) {
         char *prefix = prefixes[j];
         if (strncmp(argument,
                     prefix,


### PR DESCRIPTION
Some of the comparisons being done on prefixes, should have been size_t to
being with.  Rather than cast, change the type instead.
